### PR TITLE
A fix for offline players

### DIFF
--- a/src/main/java/lain/mods/skinport/init/forge/ClientProxy.java
+++ b/src/main/java/lain/mods/skinport/init/forge/ClientProxy.java
@@ -61,15 +61,12 @@ public class ClientProxy extends CommonProxy {
 
     public static ResourceLocation bindTexture(GameProfile profile, ResourceLocation result) {
         if (profile != null) {
-            LOGGER.debug("Binding texture for profile: {}", profile.getName());
             ISkin skin = SkinProviderAPI.SKIN.getSkin(PlayerProfile.wrapGameProfile(profile));
             if (skin != null && skin.isDataReady()) {
                 ResourceLocation location = ClientProxy.getOrCreateTexture(skin.getData(), skin)
                     .getLocation();
-                LOGGER.debug("Bound texture for {}: {}", profile.getName(), location);
                 return location;
             }
-            LOGGER.debug("No skin data ready for {}", profile.getName());
         }
         return null;
     }
@@ -95,28 +92,22 @@ public class ClientProxy extends CommonProxy {
     }
 
     public static ResourceLocation getLocationCape(AbstractClientPlayer player, ResourceLocation result) {
-        LOGGER.debug("Getting cape location for player: {}", player.getCommandSenderName());
         ISkin skin = SkinProviderAPI.CAPE.getSkin(PlayerProfile.wrapGameProfile(player.getGameProfile()));
         if (skin != null && skin.isDataReady()) {
             ResourceLocation location = ClientProxy.getOrCreateTexture(skin.getData(), skin)
                 .getLocation();
-            LOGGER.debug("Cape location for {}: {}", player.getCommandSenderName(), location);
             return location;
         }
-        LOGGER.debug("No cape data ready for {}", player.getCommandSenderName());
         return null;
     }
 
     public static ResourceLocation getLocationSkin(AbstractClientPlayer player, ResourceLocation result) {
-        LOGGER.debug("Getting skin location for player: {}", player.getCommandSenderName());
         ISkin skin = SkinProviderAPI.SKIN.getSkin(PlayerProfile.wrapGameProfile(player.getGameProfile()));
         if (skin != null && skin.isDataReady()) {
             ResourceLocation location = ClientProxy.getOrCreateTexture(skin.getData(), skin)
                 .getLocation();
-            LOGGER.debug("Skin location for {}: {}", player.getCommandSenderName(), location);
             return location;
         }
-        LOGGER.debug("No skin data ready for {}", player.getCommandSenderName());
         return null;
     }
 
@@ -160,12 +151,6 @@ public class ClientProxy extends CommonProxy {
         }
         String skinType = getSkinType(player);
         result = renderers.getOrDefault(skinType, result);
-        LOGGER.debug(
-            "Selected renderer for {} with skin type {}: {}",
-            player.getCommandSenderName(),
-            skinType,
-            result.getClass()
-                .getSimpleName());
         if (result instanceof SpecialRenderer) ((SpecialRenderer) result).onGetRenderer(manager, player);
         return result;
     }
@@ -175,12 +160,9 @@ public class ClientProxy extends CommonProxy {
         if (location != null) {
             ISkin skin = SkinProviderAPI.SKIN.getSkin(PlayerProfile.wrapGameProfile(player.getGameProfile()));
             if (skin != null && skin.isDataReady()) {
-                String skinType = skin.getSkinType();
-                LOGGER.debug("Skin type for {}: {}", player.getCommandSenderName(), skinType);
-                return skinType;
+                return skin.getSkinType();
             }
         }
-        LOGGER.debug("Using default skin type for {}", player.getCommandSenderName());
         return "default";
     }
 

--- a/src/main/java/lain/mods/skinport/init/forge/ForgeSkinPort.java
+++ b/src/main/java/lain/mods/skinport/init/forge/ForgeSkinPort.java
@@ -43,26 +43,20 @@ public class ForgeSkinPort {
 
         private static final int HASH_MASK = 0x1;
 
-        private final ISkin defaultSteve;
-        private final ISkin defaultAlex;
+        private final byte[] defaultSteve;
+        private final byte[] defaultAlex;
 
         DefaultSkinProvider() {
-            ISkin steve = null;
-            ISkin alex = null;
+            byte[] steve = null;
+            byte[] alex = null;
 
             try {
                 LOGGER.debug("Loading default Steve skin");
-                byte[] steveData = IOUtils.toByteArray(DefaultSkinProvider.class.getResource("/DefaultSteve.png"));
-                SkinData steveSkin = new SkinData();
-                steveSkin.put(steveData, "default");
-                steve = steveSkin;
+                steve = IOUtils.toByteArray(DefaultSkinProvider.class.getResource("/DefaultSteve.png"));
                 LOGGER.debug("Default Steve skin loaded successfully");
 
                 LOGGER.debug("Loading default Alex skin");
-                byte[] alexData = IOUtils.toByteArray(DefaultSkinProvider.class.getResource("/DefaultAlex.png"));
-                SkinData alexSkin = new SkinData();
-                alexSkin.put(alexData, "slim");
-                alex = alexSkin;
+                alex = IOUtils.toByteArray(DefaultSkinProvider.class.getResource("/DefaultAlex.png"));
                 LOGGER.debug("Default Alex skin loaded successfully");
             } catch (IOException e) {
                 LOGGER.error("Failed to load default skins", e);
@@ -77,10 +71,18 @@ public class ForgeSkinPort {
             UUID uuid = profile.getPlayerID();
             if (uuid != null && (uuid.hashCode() & HASH_MASK) == 1) {
                 LOGGER.debug("Using default Alex skin for player: {} (UUID: {})", profile.getPlayerName(), uuid);
-                return defaultAlex;
+                return createSkin(defaultAlex, "slim");
             }
             LOGGER.debug("Using default Steve skin for player: {} (UUID: {})", profile.getPlayerName(), uuid);
-            return defaultSteve;
+            return createSkin(defaultSteve, "default");
+        }
+
+        private ISkin createSkin(byte[] data, String type) {
+            if (data == null) return null;
+
+            SkinData skin = new SkinData();
+            skin.put(data, type);
+            return skin;
         }
 
     }

--- a/src/main/java/lain/mods/skinport/init/forge/ForgeSkinPort.java
+++ b/src/main/java/lain/mods/skinport/init/forge/ForgeSkinPort.java
@@ -2,6 +2,7 @@ package lain.mods.skinport.init.forge;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.UUID;
@@ -47,33 +48,33 @@ public class ForgeSkinPort {
         private final byte[] defaultAlex;
 
         DefaultSkinProvider() {
-            byte[] steve = null;
-            byte[] alex = null;
+            this.defaultSteve = loadDefaultSkin("/DefaultSteve.png");
+            this.defaultAlex = loadDefaultSkin("/DefaultAlex.png");
+        }
 
-            try {
-                LOGGER.debug("Loading default Steve skin");
-                steve = IOUtils.toByteArray(DefaultSkinProvider.class.getResource("/DefaultSteve.png"));
-                LOGGER.debug("Default Steve skin loaded successfully");
-
-                LOGGER.debug("Loading default Alex skin");
-                alex = IOUtils.toByteArray(DefaultSkinProvider.class.getResource("/DefaultAlex.png"));
-                LOGGER.debug("Default Alex skin loaded successfully");
-            } catch (IOException e) {
-                LOGGER.error("Failed to load default skins", e);
+        private static byte[] loadDefaultSkin(String resource) {
+            LOGGER.debug("Loading default skin: {}", resource);
+            URL url = DefaultSkinProvider.class.getResource(resource);
+            if (url == null) {
+                LOGGER.error("Default skin resource not found on classpath: {}", resource);
+                return null;
             }
-
-            this.defaultSteve = steve;
-            this.defaultAlex = alex;
+            try {
+                byte[] data = IOUtils.toByteArray(url);
+                LOGGER.debug("Default skin loaded successfully: {} ({} bytes)", resource, data.length);
+                return data;
+            } catch (IOException e) {
+                LOGGER.error("Failed to load default skin: {}", resource, e);
+                return null;
+            }
         }
 
         @Override
         public ISkin getSkin(IPlayerProfile profile) {
             UUID uuid = profile.getPlayerID();
             if (uuid != null && (uuid.hashCode() & HASH_MASK) == 1) {
-                LOGGER.debug("Using default Alex skin for player: {} (UUID: {})", profile.getPlayerName(), uuid);
                 return createSkin(defaultAlex, "slim");
             }
-            LOGGER.debug("Using default Steve skin for player: {} (UUID: {})", profile.getPlayerName(), uuid);
             return createSkin(defaultSteve, "default");
         }
 


### PR DESCRIPTION
Fixes corrupted-looking skins/models for offline players using the default Steve/Alex fallback.

The default skin provider previously reused shared SkinData instances. Those could be cleared during normal cache removal, which left later fallback renders with invalid skin data.

This changes the provider to keep the bundled default skin PNG bytes and create a fresh SkinData instance per fallback request. It also hardens default skin resource loading and removes noisy debug logging from the fallback path.

<img width="312" height="326" alt="image" src="https://github.com/user-attachments/assets/b1b40496-4c52-41f5-a08d-141888c5c4ea" />

<img width="350" height="379" alt="image" src="https://github.com/user-attachments/assets/625e3a5e-3178-46a7-9695-02f8a2bbdc74" />
